### PR TITLE
Enable rubocop for db/*

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -1,7 +1,7 @@
 AllCops:
   NewCops: enable
   Exclude:
-    - "db/**/*"
+    - "db/schema.rb"
     - "tmp/**/*"
     - "log/**/*"
 


### PR DESCRIPTION
I realized that there are a lot of cops for migrations in particular so we need to enable it for the new ones at least.
For the older migrations it is going to be `--auto-correct --disable-uncorrectable` In order to automate the process 100%