### PR TITLE
Exclude config/application.rb from Style/ClassAndModuleChildren

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -82,6 +82,8 @@ Style/Alias:
 
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact
+  Exclude:
+    - "config/application.rb"
 
 Style/CommandLiteral:
   EnforcedStyle: percent_x


### PR DESCRIPTION
Zeitwerk doesn't work at this point, so ruby can't automatically define the module.